### PR TITLE
dependency: Bump pixi.js to version 4.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8488,9 +8488,9 @@
       "integrity": "sha512-aNG9xAFyYtiT9NzZ8QPluoS7NF0lPWCGtESEAJDwbxEp8KKANw8UCcPFtZ6XWypMw24nbPUC47qzkftlY/3UUQ=="
     },
     "pixi.js": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-4.7.2.tgz",
-      "integrity": "sha512-EWhPRVxWjxeAbFqQfiCRmglmC6B4ON45q2V6NjG8ub6SIRLYexMuSypd0QprCLyWjzziUPDBfrs/x2MkND7ILA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-4.7.3.tgz",
+      "integrity": "sha512-uYCTtjYiqSpwN2kZLmjwAL+1yrdCL/pVI+waYlkVqAHBnuQCpOuGA/0UunbxZ4T13xVZ4wN+ftPlEjxWl0th3w==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "earcut": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "babel-polyfill": "6.26.0",
     "pixi-particles": "3.0.0",
-    "pixi.js": "4.7.2"
+    "pixi.js": "4.7.3"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION
This PR closes #8. 